### PR TITLE
upgrade to babel 7 (and do not transpile src files)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["es2015"],
-  "plugins": ["transform-runtime"],
-}

--- a/package.json
+++ b/package.json
@@ -4,30 +4,21 @@
   "description": "Simplified imports and exports",
   "repository": "finom/babel-plugin-transform-es2015-modules-simple-commonjs",
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "dependencies": {
-    "babel-plugin-transform-strict-mode": "^6.8.0",
-    "babel-runtime": "^6.3.19",
-    "babel-template": "^6.3.13",
-    "better-log": "^1.3.1"
+    "@babel/plugin-transform-strict-mode": "^7.14.5"
   },
   "devDependencies": {
-    "babel-cli": "^6.3.17",
-    "babel-core": "^6.3.21",
-    "babel-plugin-transform-runtime": "^6.3.13",
-    "babel-preset-es2015": "^6.5.0",
-    "babel-preset-es2015-webpack": "^6.4.1",
-    "babel-register": "^6.3.13",
-    "chalk": "^1.1.0",
-    "clear": "0.0.1",
-    "diff": "^1.4.0",
-    "watch": "^0.16.0"
+    "@babel/core": "^7.14.6",
+    "chalk": "^4.1.1",
+    "clear": "0.1.0",
+    "diff": "^5.0.0",
+    "watch": "^1.0.2"
   },
   "scripts": {
-    "release": "babel src --out-dir dist",
     "test": "node test",
     "watch": "node test --watch",
-    "prepublish": "npm test && npm run release"
+    "prepublishOnly": "npm test && npm run release"
   },
   "keywords": [
     "babel-plugin",

--- a/test/fixtures/aux-comment/actual.js
+++ b/test/fixtures/aux-comment/actual.js
@@ -7,7 +7,8 @@ import {bar} from "foo4";
 import {foo as bar2} from "foo5";
 /* comment 1*/
 export {test};
-export var test = 5;
+var test = 5;
+export var test2 = 42;
 
 bar(foo, bar2);
 

--- a/test/fixtures/aux-comment/expected.js
+++ b/test/fixtures/aux-comment/expected.js
@@ -22,10 +22,10 @@ require("./directory/foo-bar");
 
 /* comment 1*/
 exports.test = test;
-var test = exports.test = 5;
-
+var test = 5;
+var test2 = exports.test2 = 42;
 bar(foo, bar2);
-
 /* my comment */
+
 bar2;
 foo;

--- a/test/fixtures/babel-runtime/actual.js
+++ b/test/fixtures/babel-runtime/actual.js
@@ -1,3 +1,3 @@
-import classCallCheck from 'babel-runtime/class-call-check';
-import { default as a, b} from 'babel-runtime/a';
-import * as c from 'babel-runtime/b';
+import classCallCheck from '@babel/runtime/class-call-check';
+import { default as a, b} from '@babel/runtime/a';
+import * as c from '@babel/runtime/b';

--- a/test/fixtures/babel-runtime/expected.js
+++ b/test/fixtures/babel-runtime/expected.js
@@ -1,12 +1,12 @@
-'use strict';
+"use strict";
 
-var classCallCheck = require('babel-runtime/class-call-check').default;
+var classCallCheck = require('@babel/runtime/class-call-check').default;
 
-var _babelRuntimeA = require('babel-runtime/a');
+var _babelRuntimeA = require('@babel/runtime/a');
 
 var a = _babelRuntimeA.default;
 var b = _babelRuntimeA.b;
 
-var _babelRuntimeB = require('babel-runtime/b');
+var _babelRuntimeB = require('@babel/runtime/b');
 
 var c = _babelRuntimeB;

--- a/test/fixtures/basic/expected.js
+++ b/test/fixtures/basic/expected.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 var a = require('/path/to/a');
 
@@ -25,5 +25,4 @@ require('/path/to/d');
 
 doSomething();
 module.exports = x + y;
-
 doSomethingElse();

--- a/test/fixtures/classexpression/actual.js
+++ b/test/fixtures/classexpression/actual.js
@@ -1,11 +1,7 @@
 import a from '/path/to/a';
 doSomething();
 export default class x {
-	constructor() {
-
-	}
-	func() {
-		
-	}
-};
+	constructor() {}
+	func() {}
+}
 doSomethingElse();

--- a/test/fixtures/classexpression/expected.js
+++ b/test/fixtures/classexpression/expected.js
@@ -1,26 +1,12 @@
-'use strict';
-
-var _classCallCheck = require('babel-runtime/helpers/classCallCheck').default;
-
-var _createClass = require('babel-runtime/helpers/createClass').default;
+"use strict";
 
 var a = require('/path/to/a');
 
 doSomething();
+module.exports = class x {
+  constructor() {}
 
-var x = function () {
-	function x() {
-		_classCallCheck(this, x);
-	}
+  func() {}
 
-	_createClass(x, [{
-		key: 'func',
-		value: function func() {}
-	}]);
-
-	return x;
-}();
-
-module.exports = x;
-;
+};
 doSomethingElse();

--- a/test/fixtures/commonjs-names/expected.js
+++ b/test/fixtures/commonjs-names/expected.js
@@ -1,10 +1,9 @@
-'use strict';
+"use strict";
 
 var a = require('a');
 
 var _require = 1,
     _module = 2,
     _exports = 3;
-
 var b = 1;
 module.exports = b;

--- a/test/fixtures/export-arrow/actual.js
+++ b/test/fixtures/export-arrow/actual.js
@@ -1,5 +1,3 @@
-export var foo = function(gen, ctx = null) {
-}
+export var foo = function(gen, ctx = null) {}
 
-export var bar = (gen, ctx = null) => {
-}
+export var bar = (gen, ctx = null) => {}

--- a/test/fixtures/export-arrow/expected.js
+++ b/test/fixtures/export-arrow/expected.js
@@ -1,9 +1,5 @@
 "use strict";
 
-var foo = exports.foo = function foo(gen) {
-  var ctx = arguments.length <= 1 || arguments[1] === undefined ? null : arguments[1];
-};
+var foo = exports.foo = function (gen, ctx = null) {};
 
-var bar = exports.bar = function bar(gen) {
-  var ctx = arguments.length <= 1 || arguments[1] === undefined ? null : arguments[1];
-};
+var bar = exports.bar = (gen, ctx = null) => {};

--- a/test/fixtures/export-from-default/actual.js
+++ b/test/fixtures/export-from-default/actual.js
@@ -1,2 +1,1 @@
-export { a as default } from 'e';
 export { default } from 'f';

--- a/test/fixtures/export-from-default/expected.js
+++ b/test/fixtures/export-from-default/expected.js
@@ -1,8 +1,5 @@
-'use strict';
-
-var _e = require('e');
+"use strict";
 
 var _f = require('f');
 
-module.exports = _e.a;
 module.exports = _f;

--- a/test/fixtures/export-from-named-default/actual.js
+++ b/test/fixtures/export-from-named-default/actual.js
@@ -1,0 +1,1 @@
+export { a as default } from 'e';

--- a/test/fixtures/export-from-named-default/expected.js
+++ b/test/fixtures/export-from-named-default/expected.js
@@ -1,0 +1,5 @@
+"use strict";
+
+var _e = require('e');
+
+module.exports = _e.a;

--- a/test/fixtures/export-from/expected.js
+++ b/test/fixtures/export-from/expected.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 var _e = require('e');
 

--- a/test/fixtures/export-named/expected.js
+++ b/test/fixtures/export-named/expected.js
@@ -1,35 +1,26 @@
 "use strict";
 
-var _classCallCheck = require("babel-runtime/helpers/classCallCheck").default;
-
-var _createClass = require("babel-runtime/helpers/createClass").default;
-
 var a = exports.a = 1,
     aa = exports.aa = 2;
-var b = exports.b = 1,
-    bb = exports.bb = 2;
-var c = exports.c = 1,
+const b = exports.b = 1,
+      bb = exports.bb = 2;
+let c = exports.c = 1,
     cc = exports.cc = 3;
+
 function d() {
-	doSomething();
+  doSomething();
 }
+
 exports.d = d;
 
-var e = exports.e = function () {
-	function e() {
-		_classCallCheck(this, e);
-	}
+class e {
+  doSomething() {
+    doSomethingElse();
+  }
 
-	_createClass(e, [{
-		key: "doSomething",
-		value: function doSomething() {
-			doSomethingElse();
-		}
-	}]);
+}
 
-	return e;
-}();
-
+exports.e = e;
 var f = 1;
 var h = 1;
 var i = 1;

--- a/test/fixtures/functionexpression/actual.js
+++ b/test/fixtures/functionexpression/actual.js
@@ -2,5 +2,5 @@ import a from '/path/to/a';
 doSomething();
 export default function x() {
 	hey();
-};
+}
 doSomethingElse();

--- a/test/fixtures/functionexpression/expected.js
+++ b/test/fixtures/functionexpression/expected.js
@@ -1,10 +1,12 @@
-'use strict';
+"use strict";
 
 var a = require('/path/to/a');
 
 doSomething();
 module.exports = x;
+
 function x() {
-	hey();
-};
+  hey();
+}
+
 doSomethingElse();

--- a/test/fixtures/import-default/expected.js
+++ b/test/fixtures/import-default/expected.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 var _a = require('./a');
 

--- a/test/fixtures/import-mixing/expected.js
+++ b/test/fixtures/import-mixing/expected.js
@@ -4,7 +4,5 @@ var _foo = require("foo");
 
 var foo = _foo;
 var a = _foo.bar;
-
-
 foo;
 a;

--- a/test/fixtures/module-shadow/actual.js
+++ b/test/fixtures/module-shadow/actual.js
@@ -1,1 +1,1 @@
-export function module() {};
+export function module() {}

--- a/test/fixtures/module-shadow/expected.js
+++ b/test/fixtures/module-shadow/expected.js
@@ -1,4 +1,5 @@
 "use strict";
 
-function _module() {}exports.module = _module;
-;
+function _module() {}
+
+exports.module = _module;

--- a/test/fixtures/single-import/expected.js
+++ b/test/fixtures/single-import/expected.js
@@ -1,3 +1,3 @@
-'use strict';
+"use strict";
 
 require('a');

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,10 @@
 var assert = require('assert');
-var babel = require('babel-core');
+var babel = require('@babel/core');
 var chalk = require('chalk');
 var clear = require('clear');
 var diff = require('diff');
 var fs = require('fs');
 var path = require('path');
-
-require('babel-register');
 
 var pluginPath = require.resolve('../src');
 
@@ -25,6 +23,7 @@ function runTests() {
 
 function runTest(dir) {
 	var output = babel.transformFileSync(dir.path + '/actual.js', {
+    babelrc: false,
 		plugins: [pluginPath]
 	});
 


### PR DESCRIPTION
i have upgraded the module to use babel 7. i also think the package should be renamed to 
babel-plugin-transform-modules-simple-commonjs since babel dropped es2015 from all their packages when babel 7 was released. adding husky, eslint, prettier and friends would also be nice.